### PR TITLE
Remove duplicate rel

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 	<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
 	<link rel="stylesheet" href="fancybox/jquery.fancybox-v=2.1.5.css" type="text/css" media="screen">
-  <link rel="stylesheet" href="css/font-awesome.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/font-awesome.min.css">
 
 	<link href='css/GoogleApiTitilliumWeb.css' type='text/css' rel="stylesheet"> <!-- POlice utilisée --> <!-- importé depuis google api-->
 


### PR DESCRIPTION
Hi total stranger, I stumbled on this by PURE CHANCE repo.
I noticed a small mistake on the css declaration, the rel attribute is duplicate:
`<link rel="stylesheet" href="css/font-awesome.min.css" rel="stylesheet">`
